### PR TITLE
Added catkin files and env-hooks to set the LUA_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(rfsm)
+
+find_package(catkin REQUIRED)
+catkin_package()
+catkin_add_env_hooks(10.rfsm SHELLS sh DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+file(GLOB LUA_FILES "*.lua")
+install(
+  FILES ${LUA_FILES}
+  DESTINATION ${CATKIN_GLOBAL_SHARE_DESTINATION}/lua/5.1/rfsm/
+)
+
+install(
+  PROGRAMS tools/rfsm-sim tools/rfsm-viz tools/rfsm2json
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(
+  FILES tools/rfsm-sim.lua
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+

--- a/env-hooks/10.rfsm.sh.develspace.in
+++ b/env-hooks/10.rfsm.sh.develspace.in
@@ -1,0 +1,5 @@
+#!/bin/sh
+if [ "x$LUA_PATH" = "x" ]; then
+   LUA_PATH=";"
+fi
+export LUA_PATH="$LUA_PATH;@CMAKE_CURRENT_SOURCE_DIR@/?.lua"

--- a/env-hooks/10.rfsm.sh.installspace.in
+++ b/env-hooks/10.rfsm.sh.installspace.in
@@ -1,0 +1,5 @@
+#!/bin/sh
+if [ "x$LUA_PATH" = "x" ]; then
+   LUA_PATH=";"
+fi
+export LUA_PATH="$LUA_PATH;@CMAKE_INSTALL_PREFIX@/share/lua/5.1/rfsm/?.lua"

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,9 +1,0 @@
-<package>
-  <description brief="rFSM reduced Statecharts">
-    This package contains the rFSM flavor of Statecharts.
-  </description>
-  <author>Markus Klotzbuecher, markus.klotzbuecher@mech.kuleuven.be</author>
-  <url>http://people.mech.kuleuven.be/~mklotzbucher/rfsm/README.html</url>
-  <license>Dual LGPL/BSD</license>
-  <review status="unreviewed" notes=""/>
-</package>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package>
+  <name>rfsm</name>
+  <version>1.0.0</version>
+  <description>This package contains the rFSM flavor of Statecharts.</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <maintainer email="orocos-dev@lists.mech.kuleuven.be">Orocos Developers</maintainer>
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <license>LGPL</license>
+  <license>BSD</license>
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <url type="website">http://people.mech.kuleuven.be/~mklotzbucher/rfsm/README.html</url>
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <author email="markus.klotzbuecher@mech.kuleuven.be">Markus Klotzbuecher</author>
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <buildtool_depend>catkin</buildtool_depend>
+
+</package>


### PR DESCRIPTION
Make it possible to seamlessly include rFSM in a catkin workspace and use bloom to release it in the ROS ecosystem.
