### PR TITLE
Readded manifest.xml file to not break rFSM for fuerte and earlier

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -1,0 +1,9 @@
+<package>
+  <description brief="rFSM reduced Statecharts">
+    This package contains the rFSM flavor of Statecharts.
+  </description>
+  <author>Markus Klotzbuecher, markus.klotzbuecher@mech.kuleuven.be</author>
+  <url>http://people.mech.kuleuven.be/~mklotzbucher/rfsm/README.html</url>
+  <license>Dual LGPL/BSD</license>
+  <review status="unreviewed" notes=""/>
+</package>


### PR DESCRIPTION
This pull request re-adds the `manifest.xml` that has been removed in 6bee1ada36c3b1fafb24f28a5774062d62723c95.
It is required for older ROS releases (fuerte and earlier).

See http://lists.mech.kuleuven.be/pipermail/orocos-dev/2014-February/012797.html.
