### PR TITLE
Fix deprecated unpack(arg)

### DIFF
--- a/tools/rfsm-sim.lua
+++ b/tools/rfsm-sim.lua
@@ -35,7 +35,7 @@ end
 
 -- operational
 function se(...)
-   rfsm.send_events(fsm, unpack(arg))
+   rfsm.send_events(fsm, ...)
 end
 
 function ses(...)


### PR DESCRIPTION
Rest of functions use `...` syntax
