### PR TITLE
Fixing rfsm-viz output location bug invalid escape sequence near '\.'

### DIFF
--- a/tools/rfsm-viz
+++ b/tools/rfsm-viz
@@ -69,7 +69,7 @@ if verbose then
    print("file format:     ", opt_format)
 end
 
-outfile = string.gsub(infile, "\.%w*$", "")
+outfile = string.gsub(infile, ".%w*$", "")
 fsm_tpl = assert(rfsm.load(infile), "failed to open fsm file " .. infile)
 fsm = assert(rfsm.init(fsm_tpl), "error: state machine checking failed.")
 


### PR DESCRIPTION
Proposing fix for issue https://github.com/kmarkus/rFSM/issues/12