### PR TITLE
resolved problem while using the timeevent module

### DIFF
--- a/rfsm_timeevent.lua
+++ b/rfsm_timeevent.lua
@@ -36,8 +36,6 @@
 -- function (check_act_timeevents) calls all check_ handlers of the
 -- current active states during post_step_hook.
 
-require "time"
-require "rfsm"
 
 local utils=require("utils")
 local assert = assert
@@ -45,8 +43,8 @@ local type = type
 local tonumber = tonumber
 local math = math
 local string = string
-local rfsm = rfsm
-local time = time
+local rfsm = require('rfsm')
+local time = require('time')
 local ts2str = time.ts2str
 
 module 'rfsm_timeevent'


### PR DESCRIPTION
Hello,
while running a state machine in orocos, using the time event, i got the following error
```
    LuaComponent 'Supervisor': ...n/ws_noetic/ws_multi_arm/src/rFSM/rfsm_timeevent.lua:50: attempt to index local 'time' (a nil value)
``` 
I do not know why this behaviour emerged but changing  the `require "time"` to `local time=require('time')` seems to fix the problem.
PS:
I am using in noetic/orocos ubuntu 20