### PR TITLE
Fix timespec conversion to nanoseconds

### DIFF
--- a/rfsm_timeevent.lua
+++ b/rfsm_timeevent.lua
@@ -70,7 +70,7 @@ local function gen_rel_timeevent_mgr(name, timespec, sendf, fsm)
    assert(type(gettime) == 'function',
 	  "rfsm_timeevent error. Failed to install handlers: no gettime function set.")
 
-   local ts = { sec=math.floor(timespec), nsec=((timespec%1)*100000000) }
+   local ts = { sec=math.floor(timespec), nsec=((timespec%1)*10^9) }
    local tend = { sec=false, nsec=false }
    local tcur = { sec=false, nsec=false }
    local fired=false


### PR DESCRIPTION
1 second contains 1e9 nanoseconds. The conversion was off by a factor of 10
causing time-event transitions to happen sooner than expected.