### PR TITLE
Add workaround for timespec conversion with LNUM applied

### DIFF
--- a/time.lua
+++ b/time.lua
@@ -100,7 +100,7 @@ end
 --- Convert a timespec to a string (in micro-seconds)
 --- for pretty printing purposes
 function M.ts2str(ts)
-   return ("%dus"):format(M.ts2us(ts))
+    return ("%sus"):format(tostring(M.ts2us(ts)))
 end
 
 --- Convert timespec to us


### PR DESCRIPTION
The LNUM patch (as used by OpenWRT for example) adds support for an integer type
to Lua 5.1, specifically for platforms which do not have hardware floating-point
support. The formatstring "%d" expects an integer in this case, which is not
guaranteed in this case. Converting the return value of ts2us to a string and
using this as formatting will retain the original behaviour while being
indifferent to whether it is an integer or a number.

Signed-off-by: Frank Vanbever <frank.vanbever@mind.be>