### PR TITLE
fix #19. rfsm2uml uses recursive search to find subgraphs

### DIFF
--- a/examples/subgraphs.lua
+++ b/examples/subgraphs.lua
@@ -1,0 +1,107 @@
+local rfsm = require("rfsm")
+return rfsm.state {
+
+    outer_a = rfsm.state{
+
+        middle_a = rfsm.state{
+            inner_a = rfsm.state{
+                node_a = rfsm.state{},
+                node_b = rfsm.state{},
+                rfsm.trans{src="initial", tgt="node_a"},
+                rfsm.trans{src="node_a", tgt="node_b", events={'tick'}},
+                rfsm.trans{src="node_b", tgt="node_a", events={'tick'}},
+            },
+            inner_b = rfsm.state{
+                node_c = rfsm.state{},
+                node_d = rfsm.state{},
+                rfsm.trans{src="initial", tgt="node_c"},
+                rfsm.trans{src="node_c", tgt="node_d", events={'tick'}},
+                rfsm.trans{src="node_d", tgt="node_c", events={'tick'}},
+            },
+            
+            rfsm.trans{src="initial", tgt="inner_a"},
+            rfsm.trans{src="inner_a", tgt="inner_b", events={'tick'}},
+            rfsm.trans{src="inner_b", tgt="inner_a", events={'tick'}},
+        },
+        middle_b = rfsm.state{
+            inner_c = rfsm.state{
+                node_e = rfsm.state{},
+                node_f = rfsm.state{},
+                rfsm.trans{src="initial", tgt="node_e"},
+                rfsm.trans{src="node_e", tgt="node_f", events={'tick'}},
+                rfsm.trans{src="node_f", tgt="node_e", events={'tick'}},
+            },
+            inner_d = rfsm.state{
+                node_g = rfsm.state{},
+                node_h = rfsm.state{},
+                rfsm.trans{src="initial", tgt="node_g"},
+                rfsm.trans{src="node_g", tgt="node_h", events={'tick'}},
+                rfsm.trans{src="node_h", tgt="node_g", events={'tick'}},
+            },
+
+            rfsm.trans{src="initial", tgt="inner_c"},
+            rfsm.trans{src="inner_c", tgt="inner_d", events={'tick'}},
+            rfsm.trans{src="inner_d", tgt="inner_c", events={'tick'}},
+        },
+
+        rfsm.trans{src="initial", tgt="middle_a"},
+        rfsm.trans{src="middle_a", tgt="middle_b", events={'tick'}},
+        rfsm.trans{src="middle_b", tgt="middle_a", events={'tick'}},
+
+    },
+    outer_b = rfsm.state{
+
+        middle_c = rfsm.state{
+
+            inner_e = rfsm.state{
+                node_i = rfsm.state{},
+                node_j = rfsm.state{},
+                rfsm.trans{src="initial", tgt="node_i"},
+                rfsm.trans{src="node_i", tgt="node_j", events={'tick'}},
+                rfsm.trans{src="node_j", tgt="node_i", events={'tick'}},
+            },
+            inner_f = rfsm.state{
+                node_k = rfsm.state{},
+                node_l = rfsm.state{},
+                rfsm.trans{src="initial", tgt="node_k"},
+                rfsm.trans{src="node_k", tgt="node_l", events={'tick'}},
+                rfsm.trans{src="node_l", tgt="node_k", events={'tick'}},
+            },
+            
+            rfsm.trans{src="initial", tgt="inner_e"},
+            rfsm.trans{src="inner_e", tgt="inner_f", events={'tick'}},
+            rfsm.trans{src="inner_f", tgt="inner_e", events={'tick'}},
+
+        },
+        middle_d = rfsm.state{
+
+            inner_g = rfsm.state{
+                node_m = rfsm.state{},
+                node_n = rfsm.state{},
+                rfsm.trans{src="initial", tgt="node_m"},
+                rfsm.trans{src="node_m", tgt="node_n", events={'tick'}},
+                rfsm.trans{src="node_n", tgt="node_m", events={'tick'}},
+            },
+            inner_h = rfsm.state{
+                node_o = rfsm.state{},
+                node_p = rfsm.state{},
+                rfsm.trans{src="initial", tgt="node_o"},
+                rfsm.trans{src="node_o", tgt="node_p", events={'tick'}},
+                rfsm.trans{src="node_p", tgt="node_o", events={'tick'}},
+            },
+            rfsm.trans{src="initial", tgt="inner_g"},
+            rfsm.trans{src="inner_g", tgt="inner_h", events={'tick'}},
+            rfsm.trans{src="inner_h", tgt="inner_g", events={'tick'}},
+        },
+
+        rfsm.trans{src="initial", tgt="middle_c"},
+        rfsm.trans{src="middle_c", tgt="middle_d", events={'tick'}},
+        rfsm.trans{src="middle_d", tgt="middle_c", events={'tick'}},
+
+    },
+
+    rfsm.trans{src="initial", tgt="outer_a"},
+    rfsm.trans{src="outer_a", tgt="outer_b", events={'tick'}},
+    rfsm.trans{src="outer_b", tgt="outer_a", events={'tick'}},
+
+}


### PR DESCRIPTION
## Summary

rfsm2lua::get_shandle is modified to perform a recursive search of the graph, which allows rfsm2uml to work as intended

## Design

### finding subgraphs

The existing method expects to find any **node** from the root of the graph -- this works.

Similarly, it expects to find any **subgraph** from the root of the graph -- this does not work.  Recursive search is necessary.

### algorithm quirk

Interestingly, the search algorithm behaves differently in Lua than in C.  To work around this quirk, I found it necessary to save a list of the next depth of subgraphs to visit, before recursing into them.

### finding nodes

The nodes are found with a simple O(n) method, as part of the depth first search.  Alternatively, these could be searched from the root of the graph and leverage the cgraph search implementation.

## Data

1. Code listing is provided for Lua and C, demonstrating graph build/search/query
2. Program output is provided
3. Diff output is shown to highlight the differences
4. Example complicated state machine is rendered by this merge request code

### graph.lua

```lua
require("gv")

function recurse(gh, padding)
   
    if padding == nil then -- formatting
        padding = ""
    end
   
    print(padding .. "* " .. gv.nameof(gh)) -- formatting

    -- iterate across the subgraphs
    -- recurse into each subgraph
    h = gv.firstsubg(gh)
    while gv.ok(h) do
        recurse(h, padding .. "| ") -- recurse
        h = gv.nextsubg(h, h) -- iterate
    end

    -- display the nodes under this level of graph
    nh = gv.firstnode(gh)
    while nh do
        print(padding .. "|-- " .. gv.nameof(nh))
        nh = gv.nextnode(gh, nh)
    end
        
end

g_root = gv.graph("root")

g_out_one = gv.graph(g_root, "graph_out_one")
g_out_two = gv.graph(g_root, "graph_out_two")
g_mid_one = gv.graph(g_out_one, "graph_mid_one")
g_mid_two = gv.graph(g_out_two, "graph_mid_two")
g_inn_one = gv.graph(g_mid_one, "graph_inn_one")
g_inn_two = gv.graph(g_mid_two, "graph_inn_two")

n_out_one_a = gv.node(g_out_one, "node_out_one_a")
n_out_one_b = gv.node(g_out_one, "node_out_one_b")
n_out_two_a = gv.node(g_out_two, "node_out_two_a")
n_out_two_b = gv.node(g_out_two, "node_out_two_b")
n_mid_one_a = gv.node(g_mid_one, "node_mid_one_a")
n_mid_one_b = gv.node(g_mid_one, "node_mid_one_b")
n_mid_two_a = gv.node(g_mid_two, "node_mid_two_a")
n_mid_two_b = gv.node(g_mid_two, "node_mid_two_b")

gv.write(g_root, "/dev/stdout")

print("\n*********** lua recurse *************\n")
recurse(g_root)

print("\n*********** findsubg ****************\n")
print(gv.nameof(gv.findsubg(g_root, "graph_out_one")) or "no!")
print(gv.nameof(gv.findsubg(g_root, "graph_mid_one")) or "no!")
print(gv.nameof(gv.findsubg(g_root, "graph_inn_one")) or "no!")
print(gv.nameof(gv.findsubg(g_out_one, "graph_inn_one")) or "no!")
print(gv.nameof(gv.findsubg(g_mid_one, "graph_inn_one")) or "no!")
```

```
graph root {
        node [label="\N"];
        subgraph graph_out_one {
                subgraph graph_mid_one {
                        subgraph graph_inn_one {
                        }
                        node_mid_one_a;
                        node_mid_one_b;
                }
                node_out_one_a;
                node_out_one_b;
        }
        subgraph graph_out_two {
                subgraph graph_mid_two {
                        subgraph graph_inn_two {
                        }
                        node_mid_two_a;
                        node_mid_two_b;
                }
                node_out_two_a;
                node_out_two_b;
        }
}

*********** lua recurse *************

* root
| * graph_out_one
| | * graph_mid_one
| | | * graph_inn_one
| | |-- node_mid_one_a
| | |-- node_mid_one_b
| |-- node_out_one_a
| |-- node_out_one_b
| |-- node_mid_one_a
| |-- node_mid_one_b
|-- node_out_one_a
|-- node_out_one_b
|-- node_out_two_a
|-- node_out_two_b
|-- node_mid_one_a
|-- node_mid_one_b
|-- node_mid_two_a
|-- node_mid_two_b

*********** findsubg ****************

graph_out_one
no!
no!
no!
graph_inn_one
```

### cgraph.c

```c
#include <stdio.h>
#include <cgraph.h>

#define BUF_MAX 16
void recurse_(Agraph_t *gh, char* padding)
{
    Agraph_t *h; Agnode_t *nh;

    if(padding == NULL) { // formatting
        padding = "";
    }

    printf("%s* %s\n", padding, agnameof(gh)); // formatting
   
    // iterate across the subgraphs
    // recurse into each subgraph 
    for(h = agfstsubg(gh); h; h = agnxtsubg(h)) {
        char prefix[BUF_MAX];
        sprintf(prefix, "%s| ", padding); // formatting

        recurse_(h, prefix); // recurse
    }
    
    /* display the node list under this level of graph */
    for(nh = agfstnode(gh); nh; nh = agnxtnode(gh, nh)) {
        printf("%s|-- %s\n", padding, agnameof(nh));
    }
}

int main(int argc, char **argv)
{
    Agraph_t *g_root    = agopen("root", Agundirected, NULL);
    Agraph_t *g_out_one = agsubg(g_root, "graph_out_one", TRUE);
    Agraph_t *g_out_two = agsubg(g_root, "graph_out_two", TRUE);
    Agraph_t *g_mid_one = agsubg(g_out_one,"graph_mid_one", TRUE);
    Agraph_t *g_mid_two = agsubg(g_out_two,"graph_mid_two", TRUE);
    Agraph_t *g_inn_one = agsubg(g_mid_one,"graph_inn_one", TRUE);
    Agraph_t *g_inn_two = agsubg(g_mid_two,"graph_inn_two", TRUE);

    Agnode_t *n_out_one_a = agnode(g_out_one, "node_out_one_a", TRUE),
             *n_out_one_b = agnode(g_out_one, "node_out_one_b", TRUE),
             *n_out_two_a = agnode(g_out_two, "node_out_two_a", TRUE),
             *n_out_two_b = agnode(g_out_two, "node_out_two_b", TRUE),
             *n_mid_one_a = agnode(g_mid_one, "node_mid_one_a", TRUE),
             *n_mid_one_b = agnode(g_mid_one, "node_mid_one_b", TRUE),
             *n_mid_two_a = agnode(g_mid_two, "node_mid_two_a", TRUE),
             *n_mid_two_b = agnode(g_mid_two, "node_mid_two_b", TRUE);
    ;

    agwrite(g_root, stdout);
    
    printf("*** cgraph recurse ***\n");
    recurse_(g_root, NULL);

    printf("*** find asubg ***\n");
    Agraph_t *g;
    g = agsubg(g_root, "graph_out_one", 0); printf("%s\n", g ? agnameof(g) : "no!");
    g = agsubg(g_root, "graph_mid_one", 0); printf("%s\n", g ? agnameof(g) : "no!");
    g = agsubg(g_root, "graph_inn_one", 0); printf("%s\n", g ? agnameof(g) : "no!");
    g = agsubg(g_out_one, "graph_inn_one", 0); printf("%s\n", g ? agnameof(g) : "no!");
    g = agsubg(g_mid_one, "graph_inn_one", 0); printf("%s\n", g ? agnameof(g) : "no!");

    return 0;
}
```

```bash
g++ -o cgraph cgraph.c -l cgraph -I /usr/include/graphviz -Wwrite-strings && ./cgraph
```

```
graph root {
	subgraph graph_out_one {
		subgraph graph_mid_one {
			subgraph graph_inn_one {
			}
			node_mid_one_a;
			node_mid_one_b;
		}
		node_out_one_a;
		node_out_one_b;
	}
	subgraph graph_out_two {
		subgraph graph_mid_two {
			subgraph graph_inn_two {
			}
			node_mid_two_a;
			node_mid_two_b;
		}
		node_out_two_a;
		node_out_two_b;
	}
}
*** cgraph recurse ***
* root
| * graph_out_one
| | * graph_mid_one
| | | * graph_inn_one
| | |-- node_mid_one_a
| | |-- node_mid_one_b
| |-- node_out_one_a
| |-- node_out_one_b
| |-- node_mid_one_a
| |-- node_mid_one_b
| * graph_out_two
| | * graph_mid_two
| | | * graph_inn_two
| | |-- node_mid_two_a
| | |-- node_mid_two_b
| |-- node_out_two_a
| |-- node_out_two_b
| |-- node_mid_two_a
| |-- node_mid_two_b
|-- node_out_one_a
|-- node_out_one_b
|-- node_out_two_a
|-- node_out_two_b
|-- node_mid_one_a
|-- node_mid_one_b
|-- node_mid_two_a
|-- node_mid_two_b
*** find asubg ***
graph_out_one
no!
no!
no!
graph_inn_one
```

### graph output same

lua generates an extra empty node, otherwise same graph

![graph-diff](https://github.com/kmarkus/rFSM/assets/87784967/86d00f94-be06-4d80-bcdb-8f234323502c)

### finding subgraphs

Subgraphs may be discovered only by querying their immediate parent

![find-diff](https://github.com/kmarkus/rFSM/assets/87784967/b44ad3f6-9789-42ae-bce7-34849d8565be)

### algorithm quirk

The implementations behave differently

![recurse-diff](https://github.com/kmarkus/rFSM/assets/87784967/2debd90a-6d66-4c6d-aaa0-7e05295dce81)

### example output with complicated nested state machine

![subgraphs-uml](https://github.com/kmarkus/rFSM/assets/87784967/296c8ff4-a610-4e08-84d5-362a41106dbb)

## Testing

I used this wrapper script to generate all the example state machines into png files, and they look reasonable

```bash
./run_viz.sh --noclean
```

run_viz.sh
```bash
#!/bin/bash
set -e
SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )" 
OPTION_INTERP=lua
OPTION_NOCLEAN=
OPTION_COVERAGE=

function show_help() {
  echo "$0 [--coverage] [-i | --interp]=\"${OPTION_INTERP}\" [--noclean]"
  exit 0
}

LONGOPTS=coverage,interp:,noclean,help
OPTIONS=i:,h
PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTS --name "$0" -- "$@") || exit 2
eval set -- "$PARSED"
while true; do
    case "$1" in
        --coverage)
            OPTION_COVERAGE=1
            shift 1
            ;;
	-i|--interp)
            OPTION_INTERP="$2"
            shift 2
            ;;
        --noclean)
            OPTION_NOCLEAN=1
            shift 1
            ;;
        -h|--help)
            show_help
            shift 1
            ;;
        --)
            shift
            break
            ;;
        *)
            echo error
            exit 3
            ;;
    esac
done

cd ${SCRIPT_DIR} # change to tests directory
EXAMPLES=`echo examples/*.lua`

for interp in $OPTION_INTERP; do
    echo Using interpreter: $interp

    set +e
    which $interp
    [[ $? -ne 0 ]] && continue
    set -e

    PATTERN='^Lua ([0-9][.][0-9])'
    [[ `$interp -v 2>&1` =~ $PATTERN ]] && LUA_VERSION=${BASH_REMATCH[1]} || exit

    FLAGS=""
    if [ $OPTION_COVERAGE ]; then
        rm -vf luacov.stats* # zero the coverage statistics
        FLAGS="-lluacov"
        eval "$(luarocks --lua-version ${LUA_VERSION} path --bin)"
    fi

    # on ubuntu, libgv-lua provides libgv_lua.so
    export LUA_CPATH="$LUA_CPATH;/usr/lib/x86_64-linux-gnu/graphviz/lua/?.so"
    export LUA_PATH="?.lua;$LUA_PATH"

    for t in $EXAMPLES; do
        if [ "$t" == "examples/await.lua" ]; then
            continue
        elif [ "$t" == "examples/ping-pong.lua" ]; then
            continue
        elif [ "$t" == "examples/runscript.lua" ]; then
            continue
        elif [ "$t" == "examples/timeevent.lua" ]; then
            # skip this one for now
            # needs rttlib
            # or possibly only rtp lua library
            continue
        fi
        echo -e "\n\n*********************************** $interp $t ********************************************"
        tools/rfsm-viz -f $t
    done

    if [ $OPTION_COVERAGE ]; then
        luacov
        mv luacov.report.out luacov.report.out.${LUA_VERSION}
    fi

done

if [ -z $OPTION_NOCLEAN ]; then
    rm -vf *.png
    rm -vf examples/luacov.report.out* examples/luacov.stats*
    rm -v examples/*.png
fi
```


